### PR TITLE
Hotfix/initialize linecutmodels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'nxs-analysis-tools'
-version = '0.1.3'
+version = '0.1.4'
 description = 'Reduce and transform nexus format (.nxs) scattering data.'
 readme = 'README.md'
 requires-python = '>=3.7'
@@ -71,7 +71,7 @@ dev = [
 'DOI' = 'https://doi.org/10.5281/zenodo.15186359'
 
 [tool.bumpver]
-current_version = "0.1.3"
+current_version = "0.1.4"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 tag_pattern = "vMAJOR.MINOR.PATCH[-TAG]"
 commit_message = "Bump version {old_version} -> {new_version}"

--- a/src/_meta/__init__.py
+++ b/src/_meta/__init__.py
@@ -6,5 +6,5 @@ __author__ = 'Steven J. Gomez Alvarado'
 __email__ = 'stevenjgomez@ucsb.edu'
 __copyright__ = f"2023-2025, {__author__}"
 __license__ = 'MIT'
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 __repo_url__ = 'https://github.com/stevenjgomez/nxs_analysis_tools'

--- a/src/nxs_analysis_tools/chess.py
+++ b/src/nxs_analysis_tools/chess.py
@@ -173,7 +173,7 @@ class TempDependence:
         """
         for temperature in self.temperatures:
             self.scissors[temperature] = Scissors()
-            self.scissors[temperature] = LinecutModel()
+            self.linecutmodels[temperature] = LinecutModel()
 
     def set_data(self, temperature, data):
         """


### PR DESCRIPTION
The `initialize()` method of the `TempDependence` class did not initialize the `linecutmodels` attribute, and in fact overwrote the `scissors` attribute with the linecutmodels. This has been fixed.