### PR TITLE
Add lazy loading option to load_transform by preserving NXlink

### DIFF
--- a/src/nxs_analysis_tools/chess.py
+++ b/src/nxs_analysis_tools/chess.py
@@ -188,7 +188,7 @@ class TempDependence:
         """
         self.datasets[temperature] = data
 
-    def load_transforms(self, temperatures_list=None, print_tree=True):
+    def load_transforms(self, temperatures_list=None, print_tree=True, use_nxlink=False):
         """
         Load transform datasets (from nxrefine) based on temperature.
 
@@ -196,8 +196,14 @@ class TempDependence:
         ----------
         temperatures_list : list of int or None, optional
             List of temperatures to load. If None, all available temperatures are loaded.
+        
         print_tree : bool, optional
             Whether to print the data tree upon loading. Default True.
+        
+        use_nxlink : bool, optional
+            If True, maintains the NXlink defined in the data file, which references
+            the raw data in the transform.nxs file. This saves memory when working with
+            many datasets. In this case, the axes are in reverse order. Default is False.
         """
         # Convert all temperatures to strings
         if temperatures_list:
@@ -240,7 +246,7 @@ class TempDependence:
 
             # Save dataset
             try:
-                self.datasets[self.temperatures[i]] = load_transform(path, print_tree)
+                self.datasets[self.temperatures[i]] = load_transform(path, print_tree=print_tree, use_nxlink=use_nxlink)
             except Exception as e:
                 # Report temperature that was unable to load, then raise exception.
                 temp_failed = self.temperatures[i]

--- a/src/nxs_analysis_tools/datareduction.py
+++ b/src/nxs_analysis_tools/datareduction.py
@@ -49,7 +49,7 @@ def load_data(path, print_tree=True):
     return g.entry.data
 
 
-def load_transform(path, print_tree=True):
+def load_transform(path, print_tree=True, use_nxlink=False):
     """
     Load transform data from an nxrefine output file.
 
@@ -61,16 +61,24 @@ def load_transform(path, print_tree=True):
     print_tree : bool, optional
         If True, prints the NeXus data tree upon loading. Default is True.
 
+    use_nxlink : bool, optional
+        If True, maintains the NXlink defined in the data file, which references
+        the raw data in the transform.nxs file. This saves memory when working with
+        many datasets. In this case, the axes are in reverse order. Default is False.
+
     Returns
     -------
     data : NXdata
         The loaded transform data as an NXdata object.
     """
 
-    g = nxload(path)
+    root = nxload(path)
 
-    data = NXdata(NXfield(g.entry.transform.data.nxdata.transpose(2, 1, 0), name='counts'),
-                  (g.entry.transform.Qh, g.entry.transform.Qk, g.entry.transform.Ql))
+    if use_nxlink:
+        data = root.entry.transform
+    else:
+        data = NXdata(NXfield(root.entry.transform.data.nxdata.transpose(2, 1, 0), name='counts'),
+                      (root.entry.transform.Qh, root.entry.transform.Qk, root.entry.transform.Ql))
 
     print(data.tree) if print_tree else None
 


### PR DESCRIPTION
Adds a `use_nxlink` option to `load_transform` in order to preserve the NXlink and avoid loading the dataset into memory.